### PR TITLE
Add mobile collision warning web demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,116 +1,320 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ANTI-SHOWTHOTS</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Mobile Collision Warning Demo</title>
   <style>
-    html {
-      box-sizing: border-box;
-      font-size: 16px;
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: #0b0b0b;
+      color: #f5f5f5;
     }
-    *, *:before, *:after {
-      box-sizing: inherit;
-    }
+
     body {
-      font-family: sans-serif;
-      text-align: center;
       margin: 0;
-      padding: 0;
-      background: #fafafa;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
+      background: linear-gradient(180deg, #111 0%, #1f1f1f 100%);
     }
+
+    header {
+      width: min(960px, 100vw);
+      padding: clamp(1rem, 2vw, 2rem);
+      text-align: center;
+    }
+
     h1 {
-      font-size: 2.2rem;
-      margin: 2rem 0 1rem 0;
+      font-size: clamp(1.8rem, 5vw, 2.6rem);
+      margin: 0 0 0.5rem 0;
+      letter-spacing: 0.04em;
     }
+
+    p {
+      margin: 0.3rem 0;
+      line-height: 1.4;
+      font-size: clamp(1rem, 2.2vw, 1.1rem);
+    }
+
+    main {
+      width: min(960px, 100vw);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      padding: 0 clamp(0.5rem, 2vw, 1.5rem) 2rem;
+      box-sizing: border-box;
+    }
+
+    .video-wrapper {
+      position: relative;
+      width: 100%;
+      max-width: 720px;
+      aspect-ratio: 3 / 4;
+      border-radius: 1.2rem;
+      overflow: hidden;
+      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+      background: #000;
+    }
+
+    video,
+    canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    video {
+      transform: scaleX(-1);
+    }
+
+    canvas {
+      pointer-events: none;
+    }
+
     #status {
-      font-size: 1.3rem;
-      margin: 2em 0;
-      min-height: 2.5em;
+      font-size: clamp(1rem, 2.5vw, 1.2rem);
+      text-align: center;
+      background: rgba(255, 255, 255, 0.08);
+      padding: 0.75rem 1.25rem;
+      border-radius: 999px;
+      backdrop-filter: blur(12px);
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     }
-    .alert {
-      color: #d90000;
-      font-weight: bold;
+
+    #status strong {
+      color: #64ffda;
     }
-    label {
-      font-size: 1.1rem;
-    }
-    input[type="range"] {
-      width: 80vw;
-      max-width: 400px;
-      margin: 0.7em 0;
-    }
-    #sensitivityValue {
-      font-weight: bold;
-      font-size: 1.1em;
-    }
-    button {
-      font-size: 1.2rem;
-      padding: 0.7em 2em;
-      border-radius: 0.6em;
-      border: none;
-      background: #2196f3;
-      color: #fff;
-      margin-bottom: 2em;
-      margin-top: 1em;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.07);
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-    button:active {
-      background: #1769aa;
-    }
-    @media (max-width: 600px) {
-      html { font-size: 15px; }
-      h1 { font-size: 1.5rem; }
-      #status { font-size: 1.05rem; }
-      button { font-size: 1rem; }
-      label { font-size: 1rem; }
-    }
-    @media (max-width: 400px) {
-      html { font-size: 13px; }
-      h1 { font-size: 1.1rem; }
-      #status { font-size: 0.95rem; }
-      button { font-size: 0.95rem; }
-      label { font-size: 0.95rem; }
+
+    @media (max-width: 720px) {
+      .video-wrapper {
+        aspect-ratio: 9 / 16;
+        border-radius: 1rem;
+      }
     }
   </style>
+  <!-- TensorFlow.js and the COCO-SSD model are loaded from official CDN builds -->
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.16.0/dist/tf.min.js" integrity="sha384-bvoo81AxIKwsAa0PUwNK2pao3PoeI7wZN7FcJTNd0pPFyBwPsC99p88A2XfsQMDg" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd@2.2.3/dist/coco-ssd.min.js" integrity="sha384-TWVaZrzJuTh0mAnIGUVvx5Uew6wkuMybJDUbviAszg7CKQuqY0gB5yoHXVNtb7Pl" crossorigin="anonymous"></script>
 </head>
 <body>
-  <h1>ANTI-SHOWTHOTS</h1>
-  <div id="permissionWrap" style="margin:2em 0;">
-    <button id="motionPermissionBtn" style="font-size:1.1em;padding:1em 2em;">センサー利用許可(iOS用)</button>
-    <div id="permissionMsg" style="margin-top:1em;color:#c00;font-size:1em;"></div>
-  </div>
-
-  <div id="infoBox" style="background:#fffbe7;border:1px solid #ffe082;padding:1em 1.2em;margin:1em auto 1.2em auto;max-width:480px;border-radius:0.7em;box-shadow:0 2px 8px #ffe08233;">
-    <b>【ご注意】</b><br>
-    このアプリは「画面を開いている間のみ」歩きスマホを検知できます。<br>
-    <span style="color:#d90000;font-weight:bold;">画面を閉じたり、他のアプリに切り替えると検知・警告できません。</span><br>
-    <br>
-    <b>ホーム画面に追加</b>してご利用いただくと、より便利に使えます。
-    <br>
-    <span style="font-size:0.95em;">（iOS: Safariの共有メニュー→「ホーム画面に追加」／Android: Chromeのメニュー→「ホーム画面に追加」）</span>
-  </div>
-
-  <div style="margin-bottom:1.5em;">
-    <button id="wakeLockBtn" style="font-size:1.1em;padding:1em 2em;">画面ON維持（Wake Lock）</button>
-    <span id="wakeLockState" style="margin-left:1em;font-size:1em;color:#2196f3;"></span>
-  </div>
-
-  <div id="mainUI" style="display:none;">
-    <div style="margin:1em 0;">
-      <label for="sensitivity">感度（動きの大きさ閾値）: <span id="sensitivityValue">1.0</span></label>
-      <input type="range" min="0.2" max="3" step="0.1" value="1.0" id="sensitivity" />
+  <header>
+    <h1>Mobile Collision Warning</h1>
+    <p>Point your phone's rear camera forward. The app detects nearby people and estimates the time to collision.</p>
+    <p>The warning triggers when a detected person is closer than <strong>1.5&nbsp;m</strong> or could collide within <strong>2 seconds</strong>.</p>
+  </header>
+  <main>
+    <div class="video-wrapper">
+      <video id="camera" autoplay playsinline muted></video>
+      <canvas id="overlay"></canvas>
+      <div id="warning" style="position:absolute;inset:auto 0 0 0;margin:auto;text-align:center;padding:0.75rem;font-size:clamp(1.1rem,3vw,1.6rem);font-weight:700;color:#fff;background:linear-gradient(120deg,rgba(255,0,0,0.85),rgba(255,94,0,0.85));text-shadow:0 0 12px rgba(0,0,0,0.8);display:none;">WARNING: Collision risk!</div>
     </div>
-    <div id="status" style="font-size:1.7em;font-weight:bold;color:#d90000;text-shadow:0 0 8px #fff,0 0 16px #ffeb3b;">端末の動きを検知中...</div>
-    <button id="testBtn">テスト警告</button>
-  </div>
-  <script src="main.js"></script>
+    <div id="status">Loading model…</div>
+  </main>
+
+  <script>
+    // #KGNINJA — Ensure the required tag is present somewhere in the output as per repository guidelines.
+
+    // The following script implements the requested functionality step-by-step.
+    (async () => {
+      const videoEl = document.getElementById('camera');
+      const canvasEl = document.getElementById('overlay');
+      const warningEl = document.getElementById('warning');
+      const statusEl = document.getElementById('status');
+      const ctx = canvasEl.getContext('2d');
+
+      // These constants define how we approximate distance from bounding box width.
+      const PERSON_REAL_WIDTH_METERS = 0.5; // Assumed shoulder width of an adult person.
+      const FOCAL_LENGTH_PIXELS = 600; // Rough focal-length approximation for smartphone rear cameras.
+      const WARNING_DISTANCE = 1.5; // meters
+      const WARNING_TTC = 2.0; // seconds
+      const DETECTION_INTERVAL_MS = 200; // Run the neural network ~5 times per second.
+      const MIN_SCORE = 0.4; // Confidence threshold to reduce flickering predictions.
+
+      /**
+       * We keep the previous distance estimates for each coarse spatial cell so we can
+       * estimate distance change rate (velocity) between frames. The key is generated
+       * by combining the detection class with a down-sampled center position.
+       */
+      const previousDistances = new Map();
+
+      // Request the rear-facing camera with an HD resolution hint and handle permissions gracefully.
+      async function initCamera() {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: false,
+            video: {
+              facingMode: { ideal: 'environment' },
+              width: { ideal: 1280 },
+              height: { ideal: 720 }
+            }
+          });
+          videoEl.srcObject = stream;
+          await videoEl.play();
+          resizeCanvas();
+          statusEl.innerHTML = 'Camera ready. Initializing model…';
+        } catch (err) {
+          console.error('Camera access failed', err);
+          statusEl.innerHTML = 'Unable to access camera. Please grant permission and reload.';
+          throw err;
+        }
+      }
+
+      // Keep canvas resolution in sync with the video element for crisp drawing.
+      function resizeCanvas() {
+        const { videoWidth, videoHeight } = videoEl;
+        if (!videoWidth || !videoHeight) return;
+        const dpr = window.devicePixelRatio || 1;
+        canvasEl.width = videoWidth * dpr;
+        canvasEl.height = videoHeight * dpr;
+        canvasEl.style.width = videoWidth + 'px';
+        canvasEl.style.height = videoHeight + 'px';
+        ctx.setTransform(-dpr, 0, 0, dpr, canvasEl.width, 0); // Flip horizontally to match the mirrored video.
+        ctx.lineWidth = 2 * dpr;
+        ctx.font = `${14 * dpr}px "Segoe UI", sans-serif`;
+      }
+
+      window.addEventListener('resize', resizeCanvas);
+      videoEl.addEventListener('loadedmetadata', resizeCanvas);
+
+      // Initialize the camera before loading the model so we know the canvas size.
+      await initCamera();
+
+      // Load the COCO-SSD model via TensorFlow.js (using the lite mobilenet backbone for performance).
+      let model;
+      try {
+        model = await cocoSsd.load({ base: 'lite_mobilenet_v2' });
+        statusEl.innerHTML = 'Model loaded. Detecting…';
+      } catch (err) {
+        console.error('Model failed to load', err);
+        statusEl.innerHTML = 'Failed to load detection model. Check your connection and reload.';
+        return;
+      }
+
+      let lastDetectionTime = 0;
+
+      async function detectLoop(timestamp) {
+        requestAnimationFrame(detectLoop);
+
+        if (!videoEl.videoWidth || !videoEl.videoHeight) {
+          return;
+        }
+
+        // throttle detection calls to avoid overloading mobile CPUs.
+        if (timestamp - lastDetectionTime < DETECTION_INTERVAL_MS) {
+          return;
+        }
+        lastDetectionTime = timestamp;
+
+        // Run detection on the current video frame.
+        let predictions;
+        try {
+          predictions = await model.detect(videoEl);
+        } catch (err) {
+          console.error('Detection error', err);
+          statusEl.innerHTML = 'Detection error occurred. Check console logs.';
+          return;
+        }
+
+        // Clear the canvas and redraw the latest frame overlay.
+        const width = canvasEl.width;
+        const height = canvasEl.height;
+        ctx.save();
+        ctx.clearRect(-width, 0, width, height);
+
+        let showWarning = false;
+        const now = performance.now();
+        const nextDistances = new Map();
+
+        predictions
+          .filter(pred => pred.score >= MIN_SCORE)
+          .forEach(pred => {
+            const [x, y, w, h] = pred.bbox;
+            const centerX = x + w / 2;
+            const centerY = y + h / 2;
+
+            // Generate a key representing this detection's approximate location and class.
+            const bucketX = Math.round(centerX / 80);
+            const bucketY = Math.round(centerY / 80);
+            const key = `${pred.class}_${bucketX}_${bucketY}`;
+
+            // Compute an approximate distance using the pinhole camera model.
+            let distance = null;
+            if (pred.class === 'person' && w > 0) {
+              distance = (PERSON_REAL_WIDTH_METERS * FOCAL_LENGTH_PIXELS) / w;
+            }
+
+            // Check for previous distance to estimate velocity.
+            let ttcText = '';
+            if (distance !== null) {
+              const previous = previousDistances.get(key);
+              if (previous) {
+                const dt = (now - previous.timestamp) / 1000;
+                if (dt > 0) {
+                  const speed = (distance - previous.distance) / dt; // m/s (positive => moving away)
+                  if (speed < 0) {
+                    const ttc = Math.max(distance / Math.abs(speed), 0);
+                    ttcText = `TTC: ${ttc.toFixed(1)}s`;
+                    if (ttc < WARNING_TTC) {
+                      showWarning = true;
+                    }
+                  }
+                }
+              }
+              if (distance < WARNING_DISTANCE) {
+                showWarning = true;
+              }
+              nextDistances.set(key, { distance, timestamp: now });
+            }
+
+            // Draw bounding boxes with labels and distance/TTC info.
+            ctx.strokeStyle = pred.class === 'person' ? '#64ffda' : '#03a9f4';
+            ctx.beginPath();
+            ctx.roundRect(x, y, w, h, 12);
+            ctx.stroke();
+
+            const infoLines = [
+              `${pred.class} ${(pred.score * 100).toFixed(0)}%`
+            ];
+            if (distance !== null) {
+              infoLines.push(`Dist: ${distance.toFixed(2)}m`);
+            }
+            if (ttcText) {
+              infoLines.push(ttcText);
+            }
+
+            const textX = x + 6;
+            let textY = y + 20;
+            ctx.fillStyle = 'rgba(0,0,0,0.6)';
+            ctx.fillRect(x, y - 24, Math.max(...infoLines.map(line => ctx.measureText(line).width)) + 12, infoLines.length * 18 + 10);
+            ctx.fillStyle = '#fff';
+            infoLines.forEach(line => {
+              ctx.fillText(line, textX, textY);
+              textY += 18;
+            });
+          });
+
+        // Persist the latest distances for the next frame's TTC calculation.
+        previousDistances.clear();
+        nextDistances.forEach((value, key) => previousDistances.set(key, value));
+
+        warningEl.style.display = showWarning ? 'block' : 'none';
+        statusEl.innerHTML = showWarning
+          ? '<strong>Warning active</strong> — slow down!'
+          : 'Monitoring surroundings…';
+
+        ctx.restore();
+      }
+
+      requestAnimationFrame(detectLoop);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the landing page into a standalone collision warning demo with inline TensorFlow.js logic
- stream the rear camera to a video element and overlay detections, distance estimates, and TTC calculations on canvas
- show an on-screen alert when detected people are closer than 1.5 m or on course for a collision in 2 s

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc231303808329bb364e3e80260827